### PR TITLE
overriding Magento\Cms\Block\Widget\Block to show blocks title

### DIFF
--- a/app/code/Jose/Deviget/Block/Cms/Widget/Block.php
+++ b/app/code/Jose/Deviget/Block/Cms/Widget/Block.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Jose\Deviget\Block\Cms\Widget;
+
+class Block extends \Magento\Cms\Block\Widget\Block
+{
+    public function getTitle()
+    {
+        $blockId = $this->getData('block_id');
+        $title = "";
+
+        if ($blockId) {
+            $storeId = $this->_storeManager->getStore()->getId();
+            $block = $this->_blockFactory->create();
+            $block->setStoreId($storeId)->load($blockId);
+            $title = $block->getTitle();
+        }
+
+        return $title;
+    }
+
+    protected function _toHtml()
+    {
+        $this->setModuleName($this->extractModuleName('Magento\Cms\Block\Widget\Block'));
+        return parent::_toHtml();
+    }
+}

--- a/app/code/Jose/Deviget/etc/di.xml
+++ b/app/code/Jose/Deviget/etc/di.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/ObjectManager/etc/config.xsd">
+    <preference for="Magento\Cms\Block\Widget\Block" type="Jose\Deviget\Block\Cms\Widget\Block" />
+</config>

--- a/app/code/Jose/Deviget/etc/module.xml
+++ b/app/code/Jose/Deviget/etc/module.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
+    <module name="Jose_Deviget" setup_version="0.0.1"/>
+</config>

--- a/app/code/Jose/Deviget/registration.php
+++ b/app/code/Jose/Deviget/registration.php
@@ -1,0 +1,7 @@
+<?php
+
+\Magento\Framework\Component\ComponentRegistrar::register(
+    \Magento\Framework\Component\ComponentRegistrar::MODULE,
+    'Jose_Deviget',
+    __DIR__
+);


### PR DESCRIPTION
Required block override to display titles on footer text widgets